### PR TITLE
refactor: rename stores to avoid confusion between exercise/training

### DIFF
--- a/app/src/components/recent-trainings.tsx
+++ b/app/src/components/recent-trainings.tsx
@@ -2,8 +2,8 @@ import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 import styled from 'styled-components';
 
-import { S3 } from '../stores/s3';
-import { Storage } from '../stores/storage';
+import { ExerciseCatalogue } from '../stores/exercise-catalogue';
+import { TrainingJournal } from '../stores/training-journal';
 import { formatDuration } from '../utils';
 import { Badge } from './badge';
 import { View } from './view';
@@ -14,21 +14,23 @@ const LeftRight = styled(View)`
 `;
 
 export interface RecentTrainingsProps {
-  storage?: Storage;
-  s3?: S3;
+  trainingJournal?: TrainingJournal;
+  exerciseCatalogue?: ExerciseCatalogue;
 }
 
-@inject('storage', 's3')
+@inject('trainingJournal', 'exerciseCatalogue')
 @observer
 export class RecentTrainings extends React.Component<RecentTrainingsProps> {
   public render(): JSX.Element | null {
-    if (!this.props.storage) {
+    if (!this.props.trainingJournal) {
       return null;
     }
     return (
       <View>
-        {this.props.storage.exercises.map(exercise => {
-          const ex = this.props.s3 && this.props.s3.getExercise(exercise.id);
+        {this.props.trainingJournal.exercises.map(exercise => {
+          const ex =
+            this.props.exerciseCatalogue &&
+            this.props.exerciseCatalogue.getExercise(exercise.id);
           if (!ex) {
             return null;
           }
@@ -37,7 +39,7 @@ export class RecentTrainings extends React.Component<RecentTrainingsProps> {
               <Badge>{ex.name}</Badge>
               <div>
                 {formatDuration(
-                  this.props.storage!.exerciseTrainingTime(exercise.id)
+                  this.props.trainingJournal!.exerciseTrainingTime(exercise.id)
                 )}
               </div>
             </LeftRight>

--- a/app/src/scenes/exercises.tsx
+++ b/app/src/scenes/exercises.tsx
@@ -9,7 +9,7 @@ import { ScrollView } from '../components/scroll-view';
 import { Space } from '../components/space';
 import { Text } from '../components/text';
 import { View } from '../components/view';
-import { Bars, S3 } from '../stores/s3';
+import { Bars, ExerciseCatalogue } from '../stores/exercise-catalogue';
 
 import placeholder180 from '../placeholder-180x90.png';
 import placeholder320 from '../placeholder-320x148.png';
@@ -46,12 +46,12 @@ class Exercise extends React.PureComponent<ExerciseProps> {
 }
 
 export interface ExercisesProps {
-  s3: S3;
+  exerciseCatalogue: ExerciseCatalogue;
 }
 
 type RouteProps = RouteComponentProps<{ category: Bars }>;
 
-@inject('s3')
+@inject('exerciseCatalogue')
 export class Exercises extends React.Component<ExercisesProps & RouteProps> {
   public render(): JSX.Element {
     return (
@@ -61,16 +61,16 @@ export class Exercises extends React.Component<ExercisesProps & RouteProps> {
             title="5 Bar Excercises"
             image={<Image source={placeholder320} width={320} height={148} />}
           />
-          {this.props.s3.data[this.props.match.params.category].map(
-            exercise => (
-              <Exercise
-                key={exercise.id}
-                to={exercise.id}
-                name={exercise.name}
-                cover={placeholder180}
-              />
-            )
-          )}
+          {this.props.exerciseCatalogue.data[
+            this.props.match.params.category
+          ].map(exercise => (
+            <Exercise
+              key={exercise.id}
+              to={exercise.id}
+              name={exercise.name}
+              cover={placeholder180}
+            />
+          ))}
         </Space>
       </ScrollView>
     );

--- a/app/src/scenes/stats.tsx
+++ b/app/src/scenes/stats.tsx
@@ -3,14 +3,14 @@ import * as React from 'react';
 
 import { Text } from '../components/text';
 import { View } from '../components/view';
-import { Storage } from '../stores/storage';
+import { TrainingJournal } from '../stores/training-journal';
 import { formatDuration } from '../utils';
 
 export interface StatsProps {
-  storage: Storage;
+  trainingJournal: TrainingJournal;
 }
 
-@inject('storage')
+@inject('trainingJournal')
 @observer
 export class Stats extends React.Component<StatsProps> {
   public render(): JSX.Element {
@@ -22,7 +22,7 @@ export class Stats extends React.Component<StatsProps> {
         <View>
           <Text>
             Total training time:{' '}
-            {formatDuration(this.props.storage.totalTrainingTime())}
+            {formatDuration(this.props.trainingJournal.totalTrainingTime())}
           </Text>
         </View>
       </>

--- a/app/src/scenes/training.tsx
+++ b/app/src/scenes/training.tsx
@@ -9,9 +9,9 @@ import { Button } from '../components/button';
 import { Editor } from '../components/editor';
 import { Text } from '../components/text';
 import { View } from '../components/view';
-import { Exercise as ExerciseStore, State } from '../stores/exercise';
-import { S3 } from '../stores/s3';
-import { Storage } from '../stores/storage';
+import { ExerciseCatalogue } from '../stores/exercise-catalogue';
+import { TrainingJournal } from '../stores/training-journal';
+import { State, TrainingSession } from '../stores/training-session';
 import { formatDuration } from '../utils';
 
 const Wrapper = styled(View)`
@@ -31,19 +31,19 @@ const LeftRight = styled(View)`
 `;
 
 export interface ExerciseProps {
-  exercise: ExerciseStore;
-  storage: Storage;
-  s3: S3;
+  trainingSession: TrainingSession;
+  trainingJournal: TrainingJournal;
+  exerciseCatalogue: ExerciseCatalogue;
 }
 
 type RouteProps = RouteComponentProps<{ id: string }>;
 
-@inject('exercise', 'storage', 's3')
+@inject('trainingSession', 'trainingJournal', 'exerciseCatalogue')
 @observer
 export class Training extends React.Component<ExerciseProps & RouteProps> {
   public render(): JSX.Element {
     const id = this.props.match.params.id;
-    const [blue, red] = this.props.s3.getBarPositions(id);
+    const [blue, red] = this.props.exerciseCatalogue.getBarPositions(id);
     return (
       <Wrapper>
         <ImageSizer>
@@ -53,7 +53,7 @@ export class Training extends React.Component<ExerciseProps & RouteProps> {
           <Text>Gesamt Trainingszeit</Text>
           <Badge>
             {formatDuration(
-              this.props.storage.exerciseTrainingTime(
+              this.props.trainingJournal.exerciseTrainingTime(
                 this.props.match.params.id
               )
             )}
@@ -73,12 +73,12 @@ export class Training extends React.Component<ExerciseProps & RouteProps> {
   }
 
   private renderState(): JSX.Element {
-    if (this.props.exercise.state !== State.NONE) {
+    if (this.props.trainingSession.state !== State.NONE) {
       return (
         <>
           <Button onPress={this.onPause}>Pause</Button>
           <Button onPress={this.onStop}>Stop</Button>
-          <div>{formatDuration(this.props.exercise.elapsedTime)}</div>
+          <div>{formatDuration(this.props.trainingSession.elapsedTime)}</div>
         </>
       );
     }
@@ -87,16 +87,16 @@ export class Training extends React.Component<ExerciseProps & RouteProps> {
 
   @bind
   private onStart(): void {
-    this.props.exercise.start(this.props.match.params.id);
+    this.props.trainingSession.start(this.props.match.params.id);
   }
 
   @bind
   private onStop(): void {
-    this.props.exercise.stop();
+    this.props.trainingSession.stop();
   }
 
   @bind
   private onPause(): void {
-    this.props.exercise.pause();
+    this.props.trainingSession.pause();
   }
 }

--- a/app/src/stores/exercise-catalogue.ts
+++ b/app/src/stores/exercise-catalogue.ts
@@ -5,7 +5,7 @@ export enum Bars {
   '5bar' = '5bar',
 }
 
-export class S3 {
+export class ExerciseCatalogue {
   public data: {
     [B in Bars]: Array<{
       bars?: {

--- a/app/src/stores/index.ts
+++ b/app/src/stores/index.ts
@@ -1,7 +1,7 @@
-import { Exercise } from './exercise';
-import { S3 } from './s3';
-import { Storage } from './storage';
+import { ExerciseCatalogue } from './exercise-catalogue';
+import { TrainingJournal } from './training-journal';
+import { TrainingSession } from './training-session';
 
-export const s3 = new S3();
-export const storage = new Storage();
-export const exercise = new Exercise(storage);
+export const exerciseCatalogue = new ExerciseCatalogue();
+export const trainingJournal = new TrainingJournal();
+export const trainingSession = new TrainingSession(trainingJournal);

--- a/app/src/stores/training-journal.ts
+++ b/app/src/stores/training-journal.ts
@@ -10,7 +10,7 @@ interface Exercise {
   trainings: Training[];
 }
 
-export class Storage {
+export class TrainingJournal {
   @observable public exercises!: Exercise[];
   private static key = 'exercises';
 
@@ -26,14 +26,14 @@ export class Storage {
 
   public load(): Exercise[] {
     if (typeof window !== 'undefined' && window.localStorage) {
-      return JSON.parse(localStorage.getItem(Storage.key) || '[]');
+      return JSON.parse(localStorage.getItem(TrainingJournal.key) || '[]');
     }
     return [];
   }
 
   public save(exercises: Exercise[]): void {
     if (typeof window !== 'undefined' && window.localStorage) {
-      localStorage.setItem(Storage.key, JSON.stringify(exercises));
+      localStorage.setItem(TrainingJournal.key, JSON.stringify(exercises));
     }
   }
 

--- a/app/src/stores/training-session.ts
+++ b/app/src/stores/training-session.ts
@@ -1,5 +1,5 @@
 import { action, computed, observable, runInAction } from 'mobx';
-import { Storage } from './storage';
+import { TrainingJournal } from './training-journal';
 
 export enum State {
   RUNNING,
@@ -7,17 +7,17 @@ export enum State {
   NONE,
 }
 
-export class Exercise {
+export class TrainingSession {
   @observable private startDate?: Date;
   @observable private endDate?: Date;
   @observable private totalDuration?: number;
   @observable public elapsedTime!: number;
   @observable public state!: State;
   private id?: string;
-  private storage: Storage;
+  private trainingJournal: TrainingJournal;
 
-  constructor(storage: Storage) {
-    this.storage = storage;
+  constructor(trainingJournal: TrainingJournal) {
+    this.trainingJournal = trainingJournal;
     runInAction(() => {
       this.state = State.NONE;
       this.elapsedTime = 0;
@@ -61,7 +61,7 @@ export class Exercise {
     if (this.startDate && typeof this.totalDuration === 'number') {
       this.totalDuration += this.endDate.getTime() - this.startDate.getTime();
 
-      this.storage.addTraining(this.id!, {
+      this.trainingJournal.addTraining(this.id!, {
         date: this.startDate,
         duration: this.totalDuration,
       });


### PR DESCRIPTION
Maybe we could also drop the prefixes "exercise" and "training" and name the stores just "catalogue", "journal" and "session".